### PR TITLE
Explicitly including set to make code compatible with gcc >= 11

### DIFF
--- a/include/o80/front_end.hpp
+++ b/include/o80/front_end.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <vector>
 #include "burster.hpp"
 #include "o80_internal/command.hpp"


### PR DESCRIPTION
gcc >= 11 fails if `set` is not imported explicitly. This PR adds the missing import.